### PR TITLE
Add utility function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ LDFLAGS=-ldflags "-X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT
 
 .PHONY: test
 test:
+	go test -race -cover ./...
+
+.PHONY: test-component
+test-component:
 	go test -race -cover ./... -component
 
 .PHONY: build

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -1,0 +1,16 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.15
+
+inputs:
+  - name: dp-component-test
+    path: dp-component-test
+
+run:
+  path: dp-component-test/ci/scripts/component.sh

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15
+    tag: latest
 
 inputs:
   - name: dp-component-test

--- a/ci/scripts/component.sh
+++ b/ci/scripts/component.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-component-test
+  #  This is required to tell memongo which binary to download, without this
+  #  memongo tries to download a binary for debian which doesn't work on the container
+  export MEMONGO_DOWNLOAD_URL=https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.23.tgz
+  make test-component
+popd

--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -3,8 +3,5 @@
 cwd=$(pwd)
 
 pushd $cwd/dp-component-test
-  #  This is required to tell memongo which binary to download, without this
-  #  memongo tries to download a binary for debian which doesn't work on the container
-  export MEMONGO_DOWNLOAD_URL=https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.23.tgz
   make test
 popd

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15
+    tag: latest
 
 inputs:
   - name: dp-component-test

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/maxcnunes/httpfake v1.2.1
+	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1
 	go.mongodb.org/mongo-driver v1.4.6
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/go-immutable-radix v1.2.0 h1:l6UW37iCXwZkZoAbEYnptSHVE/cQ5bOTPYG5W3vf9+8=
@@ -72,6 +74,8 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -109,6 +113,10 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/afero v1.2.1 h1:qgMbHoJbPbw579P+1zVY+6n4nIFuIchaIjzZ/I/Yq8M=
 github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -168,6 +176,7 @@ golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190329151228-23e29df326fe/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190416151739-9c9e1878f421/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190420181800-aa740d480789/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+// randomDBLength is the length of the string returned by RandomDatabase()
+const randomDBLength = 15
+
+// randomDBChars is the set of characters used by RandomDatabase()
+const randomDBChars = "abcdefghijklmnopqrstuvwxyz"
+
+// RandomDatabase returns a random valid mongo database name. You can use to
+// to pick a new database name for each test to isolate tests from each other
+// without having to tear down the whole server.
+//
+// This function will panic if it cannot generate a random number.
+func RandomDatabase() string {
+	b := make([]byte, randomDBLength)
+	for i := range b {
+		bigN, err := rand.Int(rand.Reader, big.NewInt(int64(len(randomDBChars))))
+		if err != nil {
+			panic(fmt.Errorf("error getting a random int: %s", err))
+		}
+		b[i] = randomDBChars[int(bigN.Int64())]
+	}
+	return string(b)
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var componentFlag = flag.Bool("component", false, "perform component tests")
+
+func TestRandomDatabase(t *testing.T) {
+	if *componentFlag {
+		t.Skip()
+	} else {
+		Convey("When the RandomDatabase function is called", t, func() {
+			s := RandomDatabase()
+			Convey("Then it returns a valid random string", func() {
+				So(s, ShouldNotBeNil)
+				So(len(s), ShouldEqual, 15)
+				for _, c := range s {
+					So(c, ShouldBeGreaterThanOrEqualTo, 'a')
+					So(c, ShouldBeLessThanOrEqualTo, 'z')
+				}
+			})
+		})
+		Convey("When the RandomDatabase function is called multiple times", t, func() {
+			seen := map[string]bool{}
+			Convey("Then it returns different values", func() {
+				for i := 0; i < 1000; i++ {
+					s := RandomDatabase()
+					So(seen[s], ShouldBeFalse)
+					seen[s] = true
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Add an utility function to randomly generate a database name. 
Currently we use the `memongo` package for this but are moving this functionality here as a first step to remove this unnecessary external dependency.

Previously, the unit test target/script was running component tests, presumably because the concourse pipeline did not define the component job. Splitting them into unit and component so to be able to run the new unit test. The concourse pipeline has now been updated to use them both.