### PR TITLE
Remove unnecessary environment variable

### DIFF
--- a/ci/scripts/component.sh
+++ b/ci/scripts/component.sh
@@ -3,8 +3,5 @@
 cwd=$(pwd)
 
 pushd $cwd/dp-component-test
-  #  This is required to tell memongo which binary to download, without this
-  #  memongo tries to download a binary for debian which doesn't work on the container
-  export MEMONGO_DOWNLOAD_URL=https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.23.tgz
   make test-component
 popd


### PR DESCRIPTION
Remove unnecessary environment variable. This is no longer needed as memongo has been removed

Missed from https://github.com/ONSdigital/dp-component-test/pull/7