### PR TITLE
Extend auth feature

### DIFF
--- a/api_feature.go
+++ b/api_feature.go
@@ -63,10 +63,16 @@ func (f *APIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I should receive the following JSON response:$`, f.IShouldReceiveTheFollowingJSONResponse)
 	ctx.Step(`^I should receive the following JSON response with status "([^"]*)":$`, f.IShouldReceiveTheFollowingJSONResponseWithStatus)
 	ctx.Step(`^I use a service auth token "([^"]*)"$`, f.IUseAServiceAuthToken)
+	ctx.Step(`^I use an X Florence user token "([^"]*)"$`, f.IUseAnXFlorenceUserToken)
 }
 
 func (f *APIFeature) IUseAServiceAuthToken(serviceAuthToken string) error {
 	f.ISetTheHeaderTo("Authorization", serviceAuthToken)
+	return nil
+}
+
+func (f *APIFeature) IUseAnXFlorenceUserToken(xFlorenceToken string) error {
+	f.ISetTheHeaderTo("X-Florence-Token", xFlorenceToken)
 	return nil
 }
 

--- a/api_feature.go
+++ b/api_feature.go
@@ -62,11 +62,11 @@ func (f *APIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I should receive the following response:$`, f.IShouldReceiveTheFollowingResponse)
 	ctx.Step(`^I should receive the following JSON response:$`, f.IShouldReceiveTheFollowingJSONResponse)
 	ctx.Step(`^I should receive the following JSON response with status "([^"]*)":$`, f.IShouldReceiveTheFollowingJSONResponseWithStatus)
-	ctx.Step(`^I use a valid service auth token "([^"]*)"$`, f.iUseAValidServiceAuthToken)
+	ctx.Step(`^I use a service auth token "([^"]*)"$`, f.IUseAServiceAuthToken)
 }
 
-func (f *APIFeature) iUseAValidServiceAuthToken(validServiceAuthToken string) error {
-	f.ISetTheHeaderTo("Authorization", validServiceAuthToken)
+func (f *APIFeature) IUseAServiceAuthToken(serviceAuthToken string) error {
+	f.ISetTheHeaderTo("Authorization", serviceAuthToken)
 	return nil
 }
 

--- a/api_feature.go
+++ b/api_feature.go
@@ -67,7 +67,7 @@ func (f *APIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 }
 
 func (f *APIFeature) IUseAServiceAuthToken(serviceAuthToken string) error {
-	f.ISetTheHeaderTo("Authorization", serviceAuthToken)
+	f.ISetTheHeaderTo("Authorization", "Bearer "+serviceAuthToken)
 	return nil
 }
 

--- a/api_feature.go
+++ b/api_feature.go
@@ -62,6 +62,12 @@ func (f *APIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I should receive the following response:$`, f.IShouldReceiveTheFollowingResponse)
 	ctx.Step(`^I should receive the following JSON response:$`, f.IShouldReceiveTheFollowingJSONResponse)
 	ctx.Step(`^I should receive the following JSON response with status "([^"]*)":$`, f.IShouldReceiveTheFollowingJSONResponseWithStatus)
+	ctx.Step(`^I use a valid service auth token "([^"]*)"$`, f.iUseAValidServiceAuthToken)
+}
+
+func (f *APIFeature) iUseAValidServiceAuthToken(validServiceAuthToken string) error {
+	f.ISetTheHeaderTo("Authorization", validServiceAuthToken)
+	return nil
 }
 
 // ISetTheHeaderTo is a default step used to set a header and associated value for the next request

--- a/authorization_feature.go
+++ b/authorization_feature.go
@@ -41,8 +41,14 @@ func (f *AuthorizationFeature) iUseAnInvalidServiceAuthToken() error {
 	return nil
 }
 
+func (f *AuthorizationFeature) zebedeeRecognisesTheServiceAuthTokenAsValid() error {
+	f.FakeAuthService.NewHandler().Get("/serviceInstancePermissions").Reply(200).BodyString(`{ "permissions": ["DELETE", "READ", "CREATE", "UPDATE"]}`)
+	return nil
+}
+
 func (f *AuthorizationFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I am not identified$`, f.iAmNotIdentified)
 	ctx.Step(`^I am identified as "([^"]*)"$`, f.iAmIdentifiedAs)
 	ctx.Step(`^I use an invalid service auth token$`, f.iUseAnInvalidServiceAuthToken)
+	ctx.Step(`^zebedee recognises the service auth token as valid$`, f.zebedeeRecognisesTheServiceAuthTokenAsValid)
 }

--- a/authorization_feature.go
+++ b/authorization_feature.go
@@ -36,7 +36,13 @@ func (f *AuthorizationFeature) iAmIdentifiedAs(username string) error {
 	return nil
 }
 
+func (f *AuthorizationFeature) iUseAnInvalidServiceAuthToken() error {
+	f.FakeAuthService.NewHandler().Get("/serviceInstancePermissions").Reply(401).BodyString(`{ "message": "CMD permissions request denied: service account not found"}`)
+	return nil
+}
+
 func (f *AuthorizationFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I am not identified$`, f.iAmNotIdentified)
 	ctx.Step(`^I am identified as "([^"]*)"$`, f.iAmIdentifiedAs)
+	ctx.Step(`^I use an invalid service auth token$`, f.iUseAnInvalidServiceAuthToken)
 }

--- a/authorization_feature.go
+++ b/authorization_feature.go
@@ -46,6 +46,11 @@ func (f *AuthorizationFeature) zebedeeRecognisesTheServiceAuthTokenAsValid() err
 	return nil
 }
 
+func (f *AuthorizationFeature) zebedeeRecognisesTheUserTokenAsInvalid() error {
+	f.FakeAuthService.NewHandler().Get("/userInstancePermissions").Reply(401).BodyString(`{ "message": "CMD permissions request denied: session not found"}`)
+	return nil
+}
+
 func (f *AuthorizationFeature) zebedeeRecognisesTheUserTokenAsValid() error {
 	f.FakeAuthService.NewHandler().Get("/userInstancePermissions").Reply(200).BodyString(`{ "permissions": ["DELETE", "READ", "CREATE", "UPDATE"]}`)
 	return nil
@@ -57,4 +62,5 @@ func (f *AuthorizationFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^zebedee recognises the service auth token as invalid$`, f.zebedeeRecognisesTheServiceAuthTokenAsInvalid)
 	ctx.Step(`^zebedee recognises the service auth token as valid$`, f.zebedeeRecognisesTheServiceAuthTokenAsValid)
 	ctx.Step(`^zebedee recognises the user token as valid$`, f.zebedeeRecognisesTheUserTokenAsValid)
+	ctx.Step(`^zebedee recognises the user token as invalid$`, f.zebedeeRecognisesTheUserTokenAsInvalid)
 }

--- a/authorization_feature.go
+++ b/authorization_feature.go
@@ -46,9 +46,15 @@ func (f *AuthorizationFeature) zebedeeRecognisesTheServiceAuthTokenAsValid() err
 	return nil
 }
 
+func (f *AuthorizationFeature) zebedeeRecognisesTheUserTokenAsValid() error {
+	f.FakeAuthService.NewHandler().Get("/userInstancePermissions").Reply(200).BodyString(`{ "permissions": ["DELETE", "READ", "CREATE", "UPDATE"]}`)
+	return nil
+}
+
 func (f *AuthorizationFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I am not identified$`, f.iAmNotIdentified)
 	ctx.Step(`^I am identified as "([^"]*)"$`, f.iAmIdentifiedAs)
 	ctx.Step(`^zebedee recognises the service auth token as invalid$`, f.zebedeeRecognisesTheServiceAuthTokenAsInvalid)
 	ctx.Step(`^zebedee recognises the service auth token as valid$`, f.zebedeeRecognisesTheServiceAuthTokenAsValid)
+	ctx.Step(`^zebedee recognises the user token as valid$`, f.zebedeeRecognisesTheUserTokenAsValid)
 }

--- a/authorization_feature.go
+++ b/authorization_feature.go
@@ -36,7 +36,7 @@ func (f *AuthorizationFeature) iAmIdentifiedAs(username string) error {
 	return nil
 }
 
-func (f *AuthorizationFeature) iUseAnInvalidServiceAuthToken() error {
+func (f *AuthorizationFeature) zebedeeRecognisesTheServiceAuthTokenAsInvalid() error {
 	f.FakeAuthService.NewHandler().Get("/serviceInstancePermissions").Reply(401).BodyString(`{ "message": "CMD permissions request denied: service account not found"}`)
 	return nil
 }
@@ -49,6 +49,6 @@ func (f *AuthorizationFeature) zebedeeRecognisesTheServiceAuthTokenAsValid() err
 func (f *AuthorizationFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I am not identified$`, f.iAmNotIdentified)
 	ctx.Step(`^I am identified as "([^"]*)"$`, f.iAmIdentifiedAs)
-	ctx.Step(`^I use an invalid service auth token$`, f.iUseAnInvalidServiceAuthToken)
+	ctx.Step(`^zebedee recognises the service auth token as invalid$`, f.zebedeeRecognisesTheServiceAuthTokenAsInvalid)
 	ctx.Step(`^zebedee recognises the service auth token as valid$`, f.zebedeeRecognisesTheServiceAuthTokenAsValid)
 }

--- a/authorization_feature.go
+++ b/authorization_feature.go
@@ -36,7 +36,7 @@ func (f *AuthorizationFeature) iAmIdentifiedAs(username string) error {
 	return nil
 }
 
-func (f *AuthorizationFeature) zebedeeRecognisesTheServiceAuthTokenAsInvalid() error {
+func (f *AuthorizationFeature) zebedeeDoesNotRecogniseTheServiceAuthToken() error {
 	f.FakeAuthService.NewHandler().Get("/serviceInstancePermissions").Reply(401).BodyString(`{ "message": "CMD permissions request denied: service account not found"}`)
 	return nil
 }
@@ -46,12 +46,14 @@ func (f *AuthorizationFeature) zebedeeRecognisesTheServiceAuthTokenAsValid() err
 	return nil
 }
 
-func (f *AuthorizationFeature) zebedeeRecognisesTheUserTokenAsInvalid() error {
+func (f *AuthorizationFeature) zebedeeDoesNotRecogniseTheUserToken() error {
 	f.FakeAuthService.NewHandler().Get("/userInstancePermissions").Reply(401).BodyString(`{ "message": "CMD permissions request denied: session not found"}`)
 	return nil
 }
 
 func (f *AuthorizationFeature) zebedeeRecognisesTheUserTokenAsValid() error {
+	//NB. These permissions are what would be returned for an Admin or Publisher user.
+	//A viewer would get empty or just "READ" if they were assigned to a team with preview access to a collection/dataset.
 	f.FakeAuthService.NewHandler().Get("/userInstancePermissions").Reply(200).BodyString(`{ "permissions": ["DELETE", "READ", "CREATE", "UPDATE"]}`)
 	return nil
 }
@@ -59,8 +61,8 @@ func (f *AuthorizationFeature) zebedeeRecognisesTheUserTokenAsValid() error {
 func (f *AuthorizationFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I am not identified$`, f.iAmNotIdentified)
 	ctx.Step(`^I am identified as "([^"]*)"$`, f.iAmIdentifiedAs)
-	ctx.Step(`^zebedee recognises the service auth token as invalid$`, f.zebedeeRecognisesTheServiceAuthTokenAsInvalid)
 	ctx.Step(`^zebedee recognises the service auth token as valid$`, f.zebedeeRecognisesTheServiceAuthTokenAsValid)
 	ctx.Step(`^zebedee recognises the user token as valid$`, f.zebedeeRecognisesTheUserTokenAsValid)
-	ctx.Step(`^zebedee recognises the user token as invalid$`, f.zebedeeRecognisesTheUserTokenAsInvalid)
+	ctx.Step(`^zebedee does not recognise the service auth token$`, f.zebedeeDoesNotRecogniseTheServiceAuthToken)
+	ctx.Step(`^zebedee does not recognise the user token$`, f.zebedeeDoesNotRecogniseTheUserToken)
 }

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -20,16 +20,20 @@ func MustAuthorize(handler http.HandlerFunc) http.HandlerFunc {
 
 func ZebedeeMustAuthorize(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		err := zebedeeValidateAuth(r.Header.Get("Authorization"))
+		status, err := zebedeeValidateAuth(r.Header.Get("Authorization"))
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusUnauthorized)
+			if status == "401 Unauthorized" {
+				http.Error(w, err.Error(), http.StatusUnauthorized)
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 			return
 		}
 		handler(w, r)
 	}
 }
 
-func zebedeeValidateAuth(token string) error {
+func zebedeeValidateAuth(token string) (string, error) {
 	if token == "" {
 		type Permissions struct {
 			Permissions string `bson:"message" json:"message"`
@@ -37,23 +41,24 @@ func zebedeeValidateAuth(token string) error {
 		var permissions Permissions
 		config := NewConfig()
 		response, err := http.Get(config.authorizationServiceUrl + "/serviceInstancePermissions")
+		status := response.Status
 		if err != nil {
-			return err
+			return status, err
 		}
 		body, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return err
+			return status, err
 		}
 		if len(body) == 0 {
-			return errors.New("user has not been authorised by zebedee")
+			return status, errors.New("user has not been authorised by zebedee")
 		}
 		err = json.Unmarshal(body, &permissions)
 		if err != nil {
-			return err
+			return status, err
 		}
-		return errors.New(permissions.Permissions)
+		return status, errors.New(permissions.Permissions)
 	}
-	return nil
+	return "", nil
 }
 
 func validateAuth(token string) error {

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -29,7 +29,7 @@ func ZebedeeMustPermitUser(handler http.HandlerFunc) http.HandlerFunc {
 
 func zebedeeValidateUser() (string, error) {
 	type Permissions struct {
-		Permissions string `bson:"message" json:"message"`
+		PermissionsMsg string `bson:"message" json:"message"`
 	}
 	var permissions Permissions
 	config := NewConfig()
@@ -38,20 +38,20 @@ func zebedeeValidateUser() (string, error) {
 	if err != nil {
 		return status, err
 	}
-	body, err := ioutil.ReadAll(response.Body)
-	defer response.Body.Close()
-	if err != nil {
-		return status, err
-	}
-	if len(body) == 0 {
-		return status, errors.New("user has not been authorised by zebedee")
-	}
-	err = json.Unmarshal(body, &permissions)
-	if err != nil {
-		return status, err
-	}
 	if status == "401 Unauthorized" {
-		return status, errors.New(permissions.Permissions)
+		body, err := ioutil.ReadAll(response.Body)
+		defer response.Body.Close()
+		if err != nil {
+			return status, err
+		}
+		if len(body) == 0 {
+			return status, errors.New("user has not been authorised by zebedee")
+		}
+		err = json.Unmarshal(body, &permissions)
+		if err != nil {
+			return status, err
+		}
+		return status, errors.New(permissions.PermissionsMsg)
 	}
 	return status, nil
 }

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -88,7 +88,7 @@ func ZebedeeMustAuthorize(handler http.HandlerFunc) http.HandlerFunc {
 
 func zebedeeValidateAuth() (string, error) {
 	type Permissions struct {
-		Permissions string `bson:"message" json:"message"`
+		PermissionsMsg string `bson:"message" json:"message"`
 	}
 	var permissions Permissions
 	config := NewConfig()
@@ -97,20 +97,20 @@ func zebedeeValidateAuth() (string, error) {
 	if err != nil {
 		return status, err
 	}
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return status, err
-	}
-	if len(body) == 0 {
-		return status, errors.New("service has not been authorised by zebedee")
-	}
-	err = json.Unmarshal(body, &permissions)
-	if err != nil {
-		return status, err
-	}
-	permMsg := permissions.Permissions
 	if status == "401 Unauthorized" {
-		return status, errors.New(permMsg)
+		body, err := ioutil.ReadAll(response.Body)
+		defer response.Body.Close()
+		if err != nil {
+			return status, err
+		}
+		if len(body) == 0 {
+			return status, errors.New("service has not been authorised by zebedee")
+		}
+		err = json.Unmarshal(body, &permissions)
+		if err != nil {
+			return status, err
+		}
+		return status, errors.New(permissions.PermissionsMsg)
 	}
 	return status, nil
 }

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -36,31 +36,31 @@ func ZebedeeMustAuthorize(handler http.HandlerFunc) http.HandlerFunc {
 }
 
 func zebedeeValidateAuth(token string) (string, error) {
-	if token == "" {
-		type Permissions struct {
-			Permissions string `bson:"message" json:"message"`
-		}
-		var permissions Permissions
-		config := NewConfig()
-		response, err := http.Get(config.authorizationServiceUrl + "/serviceInstancePermissions")
-		status := response.Status
-		if err != nil {
-			return status, err
-		}
-		body, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			return status, err
-		}
-		if len(body) == 0 {
-			return status, errors.New("user has not been authorised by zebedee")
-		}
-		err = json.Unmarshal(body, &permissions)
-		if err != nil {
-			return status, err
-		}
+	type Permissions struct {
+		Permissions string `bson:"message" json:"message"`
+	}
+	var permissions Permissions
+	config := NewConfig()
+	response, err := http.Get(config.authorizationServiceUrl + "/serviceInstancePermissions")
+	status := response.Status
+	if err != nil {
+		return status, err
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return status, err
+	}
+	if len(body) == 0 {
+		return status, errors.New("user has not been authorised by zebedee")
+	}
+	err = json.Unmarshal(body, &permissions)
+	if err != nil {
+		return status, err
+	}
+	if status == "401 Unauthorized" {
 		return status, errors.New(permissions.Permissions)
 	}
-	return "", nil
+	return status, nil
 }
 
 func validateAuth(token string) error {

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
@@ -19,6 +20,8 @@ func ZebedeeMustPermitUser(handler http.HandlerFunc) http.HandlerFunc {
 			return
 		} else {
 			w.WriteHeader(200)
+			message := "[\"DELETE\", \"READ\", \"CREATE\", \"UPDATE\"]"
+			fmt.Fprintf(w, message)
 		}
 		handler(w, r)
 	}
@@ -75,6 +78,8 @@ func ZebedeeMustAuthorize(handler http.HandlerFunc) http.HandlerFunc {
 			return
 		} else {
 			w.WriteHeader(200)
+			message := "[\"DELETE\", \"READ\", \"CREATE\", \"UPDATE\"]"
+			fmt.Fprintf(w, message)
 		}
 		handler(w, r)
 	}
@@ -102,8 +107,9 @@ func zebedeeValidateAuth() (string, error) {
 	if err != nil {
 		return status, err
 	}
+	permMsg := permissions.Permissions
 	if status == "401 Unauthorized" {
-		return status, errors.New(permissions.Permissions)
+		return status, errors.New(permMsg)
 	}
 	return status, nil
 }

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -28,6 +28,8 @@ func ZebedeeMustAuthorize(handler http.HandlerFunc) http.HandlerFunc {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 			return
+		} else {
+			w.WriteHeader(200)
 		}
 		handler(w, r)
 	}

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -12,33 +12,32 @@ func ZebedeeMustPermitUser(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		status, err := zebedeeValidateUser()
 		if err != nil {
-			if status == "401 Unauthorized" {
+			if status == 401 {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 			} else {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 			return
-		} else {
-			w.WriteHeader(200)
-			message := "[\"DELETE\", \"READ\", \"CREATE\", \"UPDATE\"]"
-			fmt.Fprintf(w, message)
 		}
+		w.WriteHeader(status)
+		message := "[\"DELETE\", \"READ\", \"CREATE\", \"UPDATE\"]"
+		fmt.Fprintf(w, message)
 		handler(w, r)
 	}
 }
 
-func zebedeeValidateUser() (string, error) {
+func zebedeeValidateUser() (int, error) {
 	type Permissions struct {
 		PermissionsMsg string `bson:"message" json:"message"`
 	}
 	var permissions Permissions
 	config := NewConfig()
 	response, err := http.Get(config.authorizationServiceUrl + "/userInstancePermissions")
-	status := response.Status
 	if err != nil {
-		return status, err
+		return 500, err
 	}
-	if status == "401 Unauthorized" {
+	status := response.StatusCode
+	if status == 401 {
 		body, err := ioutil.ReadAll(response.Body)
 		defer response.Body.Close()
 		if err != nil {
@@ -71,33 +70,32 @@ func ZebedeeMustAuthorize(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		status, err := zebedeeValidateAuth()
 		if err != nil {
-			if status == "401 Unauthorized" {
+			if status == 401 {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 			} else {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 			return
-		} else {
-			w.WriteHeader(200)
-			message := "[\"DELETE\", \"READ\", \"CREATE\", \"UPDATE\"]"
-			fmt.Fprintf(w, message)
 		}
+		w.WriteHeader(status)
+		message := "[\"DELETE\", \"READ\", \"CREATE\", \"UPDATE\"]"
+		fmt.Fprintf(w, message)
 		handler(w, r)
 	}
 }
 
-func zebedeeValidateAuth() (string, error) {
+func zebedeeValidateAuth() (int, error) {
 	type Permissions struct {
 		PermissionsMsg string `bson:"message" json:"message"`
 	}
 	var permissions Permissions
 	config := NewConfig()
 	response, err := http.Get(config.authorizationServiceUrl + "/serviceInstancePermissions")
-	status := response.Status
 	if err != nil {
-		return status, err
+		return 500, err
 	}
-	if status == "401 Unauthorized" {
+	status := response.StatusCode
+	if status == 401 {
 		body, err := ioutil.ReadAll(response.Body)
 		defer response.Body.Close()
 		if err != nil {

--- a/examples/authorized_api/authorization.go
+++ b/examples/authorized_api/authorization.go
@@ -39,6 +39,7 @@ func zebedeeValidateUser() (string, error) {
 		return status, err
 	}
 	body, err := ioutil.ReadAll(response.Body)
+	defer response.Body.Close()
 	if err != nil {
 		return status, err
 	}

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -85,7 +85,22 @@ Feature: Example feature
             ["DELETE", "READ", "CREATE", "UPDATE"]
             """
 
-    Scenario: accessing zebedee endpoint with X Florence user authorization
+    Scenario: accessing zebedee endpoint without X Florence user permissions
+
+        Given I use an X Florence user token "invalidXFlorenceToken"
+        And I am not identified
+        And zebedee recognises the user token as invalid
+        When I POST "/example6"
+            """
+            foo bar
+            """
+        Then the HTTP status code should be "401"
+        And I should receive the following response:
+            """
+            CMD permissions request denied: session not found
+            """
+
+    Scenario: accessing zebedee endpoint with X Florence user permissions
 
         Given I use an X Florence user token "validXFlorenceToken"
         And I am identified as "someone@somewhere.com"

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -58,3 +58,15 @@ Feature: Example feature
             """
             User has not been identified as an admin
             """
+
+    Scenario: accessing zebedee endpoint without authorization
+        Given I use an invalid service auth token
+        When I POST "/example5"
+            """
+            foo bar
+            """
+        Then the HTTP status code should be "401"
+        And I should receive the following response:
+            """
+            CMD permissions request denied: service account not found
+            """

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -60,7 +60,8 @@ Feature: Example feature
             """
 
     Scenario: accessing zebedee endpoint without service authorization
-        Given I use an invalid service auth token
+        Given I use a service auth token "invalidServiceAuthToken"
+        And zebedee recognises the service auth token as invalid
         When I POST "/example5"
             """
             foo bar
@@ -72,7 +73,7 @@ Feature: Example feature
             """
 
     Scenario: accessing zebedee endpoint with service authorization
-        Given I use a valid service auth token "abcdefg"
+        Given I use a service auth token "validServiceAuthToken"
         And zebedee recognises the service auth token as valid
         When I POST "/example5"
             """

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -82,7 +82,7 @@ Feature: Example feature
         Then the HTTP status code should be "200"
         And I should receive the following response:
             """
-            accepted
+            ["DELETE", "READ", "CREATE", "UPDATE"]
             """
 
     Scenario: accessing zebedee endpoint with X Florence user authorization
@@ -95,3 +95,7 @@ Feature: Example feature
             foo bar
             """
         Then the HTTP status code should be "200"
+        And I should receive the following response:
+            """
+            ["DELETE", "READ", "CREATE", "UPDATE"]
+            """

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -61,7 +61,7 @@ Feature: Example feature
 
     Scenario: accessing zebedee endpoint without service authorization
         Given I use a service auth token "invalidServiceAuthToken"
-        And zebedee recognises the service auth token as invalid
+        And zebedee does not recognise the service auth token
         When I POST "/example5"
             """
             foo bar
@@ -89,7 +89,7 @@ Feature: Example feature
 
         Given I use an X Florence user token "invalidXFlorenceToken"
         And I am not identified
-        And zebedee recognises the user token as invalid
+        And zebedee does not recognise the user token
         When I POST "/example6"
             """
             foo bar

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -59,7 +59,7 @@ Feature: Example feature
             User has not been identified as an admin
             """
 
-    Scenario: accessing zebedee endpoint without authorization
+    Scenario: accessing zebedee endpoint without service authorization
         Given I use an invalid service auth token
         When I POST "/example5"
             """
@@ -70,3 +70,15 @@ Feature: Example feature
             """
             CMD permissions request denied: service account not found
             """
+
+#    Scenario: accessing zebedee endpoint with service authorization
+#        Given I use valid service auth token "abcdefg"
+#        When I POST "/example5"
+#            """
+#            foo bar
+#            """
+#        Then the HTTP status code should be "200"
+#        And I should receive the following response:
+#            """
+#            ["DELETE", "READ", "CREATE", "UPDATE"]
+#            """

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -84,3 +84,14 @@ Feature: Example feature
             """
             accepted
             """
+
+    Scenario: accessing zebedee endpoint with X Florence user authorization
+
+        Given I use an X Florence user token "validXFlorenceToken"
+        And I am identified as "someone@somewhere.com"
+        And zebedee recognises the user token as valid
+        When I POST "/example6"
+            """
+            foo bar
+            """
+        Then the HTTP status code should be "200"

--- a/examples/authorized_api/features/example.feature
+++ b/examples/authorized_api/features/example.feature
@@ -71,14 +71,15 @@ Feature: Example feature
             CMD permissions request denied: service account not found
             """
 
-#    Scenario: accessing zebedee endpoint with service authorization
-#        Given I use valid service auth token "abcdefg"
-#        When I POST "/example5"
-#            """
-#            foo bar
-#            """
-#        Then the HTTP status code should be "200"
-#        And I should receive the following response:
-#            """
-#            ["DELETE", "READ", "CREATE", "UPDATE"]
-#            """
+    Scenario: accessing zebedee endpoint with service authorization
+        Given I use a valid service auth token "abcdefg"
+        And zebedee recognises the service auth token as valid
+        When I POST "/example5"
+            """
+            foo bar
+            """
+        Then the HTTP status code should be "200"
+        And I should receive the following response:
+            """
+            accepted
+            """

--- a/examples/authorized_api/main.go
+++ b/examples/authorized_api/main.go
@@ -47,7 +47,7 @@ func NewRouter() http.Handler {
 	router.HandleFunc("/example1", ExampleHandler1).Methods(http.MethodGet)
 	router.HandleFunc("/example3", MustAuthorize(ExampleHandler)).Methods(http.MethodPost)
 	router.HandleFunc("/example4", MustBeIdentified(ExampleHandler)).Methods(http.MethodPost)
-	router.HandleFunc("/example5", ZebedeeMustAuthorize(ExampleHandler)).Methods(http.MethodPost)
+	router.HandleFunc("/example5", ZebedeeMustAuthorize(ExampleHandler2)).Methods(http.MethodPost)
 	router.HandleFunc("/example6", ZebedeeMustPermitUser(ExampleHandler2)).Methods(http.MethodPost)
 
 	return router

--- a/examples/authorized_api/main.go
+++ b/examples/authorized_api/main.go
@@ -43,6 +43,7 @@ func NewRouter() http.Handler {
 	router.HandleFunc("/example1", ExampleHandler1).Methods(http.MethodGet)
 	router.HandleFunc("/example3", MustAuthorize(ExampleHandler)).Methods(http.MethodPost)
 	router.HandleFunc("/example4", MustBeIdentified(ExampleHandler)).Methods(http.MethodPost)
+	router.HandleFunc("/example5", ZebedeeMustAuthorize(ExampleHandler)).Methods(http.MethodPost)
 
 	return router
 }

--- a/examples/authorized_api/main.go
+++ b/examples/authorized_api/main.go
@@ -20,6 +20,10 @@ func NewConfig() *Config {
 	}
 }
 
+func ExampleHandler2(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(500)
+}
+
 func ExampleHandler1(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		ExampleType int `json:"example_type"`
@@ -44,6 +48,7 @@ func NewRouter() http.Handler {
 	router.HandleFunc("/example3", MustAuthorize(ExampleHandler)).Methods(http.MethodPost)
 	router.HandleFunc("/example4", MustBeIdentified(ExampleHandler)).Methods(http.MethodPost)
 	router.HandleFunc("/example5", ZebedeeMustAuthorize(ExampleHandler)).Methods(http.MethodPost)
+	router.HandleFunc("/example6", ZebedeeMustPermitUser(ExampleHandler2)).Methods(http.MethodPost)
 
 	return router
 }

--- a/examples/authorized_api/main_test.go
+++ b/examples/authorized_api/main_test.go
@@ -30,7 +30,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	authorizationFeature.RegisterSteps(ctx)
 }
 
-func TestMain(t *testing.T) {
+func TestComponent(t *testing.T) {
 	if *componentFlag {
 		var opts = godog.Options{
 			Output: colors.Colored(os.Stdout),


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Two scenario steps have been added to the api feature, as follows:
1. I use a service auth token
This allows a component test to set a header value to "Authorization" and pass in a string to represent the Service Auth Token value.

2. I use an X Florence user token
This allows a component test to set a header value to "X-Florence-Token" and pass in a string to represent the X Florence Token value.

Four scenario steps have been added to the authorization feature, as follows:
1. zebedee recognises the service auth token as invalid
This allows a component test to call a fake zebedee endpoint of /serviceInstancePermissions and receive a response with status 401 and the message "CMD permissions request denied: service account not found"

2. zebedee recognises the service auth token as valid
This allows a component test to call a fake zebedee endpoint of /serviceInstancePermissions and receive a response with status 200 and the message "["DELETE", "READ", "CREATE", "UPDATE"]"

4. zebedee recognises the user token as invalid
This allows a component test to call a fake zebedee endpoint of /userInstancePermissions and receive a response with status 401 and the message "CMD permissions request denied: session not found"

3. zebedee recognises the user token as valid
This allows a component test to call a fake zebedee endpoint of /userInstancePermissions and receive a response with status 200 and the message "["DELETE", "READ", "CREATE", "UPDATE"]"

Four example scenarios have been added to the example feature here: examples/authorized_api/features/example.feature

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the changes look correct.

Also, to run the example component tests, do as follows:

cd into dp-component-test/examples/authorized_api

run this command: go test -component

42 steps should pass

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
