### PR TITLE
Fix: Add Reset() to ErrorFeature

### DIFF
--- a/api_feature.go
+++ b/api_feature.go
@@ -44,6 +44,7 @@ func NewAPIFeatureWithHandler(handler http.Handler) *APIFeature {
 
 // Reset the request headers
 func (f *APIFeature) Reset() {
+	f.ErrorFeature.Reset()
 	f.requestHeaders = make(map[string]string)
 }
 

--- a/authorization_feature.go
+++ b/authorization_feature.go
@@ -19,6 +19,7 @@ type AuthorizationFeature struct {
 }
 
 func (f *AuthorizationFeature) Reset() {
+	f.ErrorFeature.Reset()
 	f.FakeAuthService.Reset()
 }
 

--- a/error_feature.go
+++ b/error_feature.go
@@ -25,6 +25,11 @@ func (t *ErrorFeature) Errorf(format string, args ...interface{}) {
 func (t *ErrorFeature) StepError() error {
 	return t.err
 }
+
+func (t *ErrorFeature) Reset() {
+	t.err = nil
+}
+
 func (t *ErrorFeature) Helper() {}
 func (t *ErrorFeature) Name() string {
 	return "Component Test"

--- a/ui_feature.go
+++ b/ui_feature.go
@@ -57,6 +57,7 @@ func (f *UIFeature) setChromeContext() {
 
 // Reset the chrome context
 func (f *UIFeature) Reset() {
+	f.ErrorFeature.Reset()
 	f.setChromeContext()
 }
 


### PR DESCRIPTION
### What

Add a Reset() to the ErrorFeature to reset the contained error
An embedded ErrorFeature should be Reset whenever the containing Feature is Reset, so add this to all features in the component-test library which contain an ErrorFeature

### How to review

Review code

### Who can review

Anyone
