### PR TITLE
Reformat readme

### DIFF
--- a/STEP_DEFINITIONS.md
+++ b/STEP_DEFINITIONS.md
@@ -14,37 +14,53 @@ This library provides these generic steps that should be useable across a variet
 
 [LIST] : represents a list of strings e.g `"item1,item2..."`.
 
-| Step                                                                                 | What it does                                                                                                                                                            | Scenario Position |
-|--------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| I am authorised                                                                      | set the request Authorization header to a random token                                                                                                                  | Given             |
-| I am not authorised                                                                  | clear any existing Authorization token from the request                                                                                                                 | Given             |
-| I am not identified                                                                  | remove the /identity endpoint from the stubbed identity server                                                                                                          | Given             |
-| I am identified as "USER"                                                            | set /identity endpoint to return response with USER identity                                                                                                            | Given             |
-| the following document exists in the "COLLECTION" collection: \_BODY\_               | put document BODY in the COLLECTION collection                                                                                                                          | Given             |
-| I set the "KEY" header to "VALUE"                                                    | set a HTTP header of the request to the value                                                                                                                           | Given             |
-| I GET "URL"                                                                          | make a GET request to the provided URL                                                                                                                                  | When              |
-| I DELETE "URL"                                                                       | make a DELETE request to the provided URL                                                                                                                               | When              |
-| I PUT "URL" "BODY"                                                                   | make a PUT request to the provided URL with the given body                                                                                                              | When              |
-| I PATCH "URL" "BODY"                                                                 | make a PATCH request to the provided URL with the given body                                                                                                            | When              |
-| I POST "URL" "BODY"                                                                  | make a POST request to the provided URL with the given body                                                                                                             | When              |
-| the HTTP status code should be "CODE"                                                | Assert that the response code from the request is CODE                                                                                                                  | Then              |
-| the response header "KEY" should be "VALUE"                                          | Assert that the response header KEY has value VALUE                                                                                                                     | Then              |
-| I should recieve the following response \_BODY\_                                     | Assert that the response body matches BODY                                                                                                                              | Then              |
-| I should receive the following JSON response: \_BODY\_                               | Assert that the response body is JSON and that ir matches BODY                                                                                                          | Then              |
-| I should receive the following JSON response with status "CODE": \_BODY\_            | Assert that the response code is CODE and the body is json which matches BODY                                                                                           | Then              |
-| I wait "SECONDS" seconds                                                             | Waits a given amount of seconds                                                                                      | Then              |
-| the document with "KEY" set to "VALUE" does not exist in the "COLLECTION" collection | Assert that a document with KEY set to VALUE does not exist in COLLECTION collection                                                                                    | Then              |
-| I navigate to "URL"                                                                  | Navigate to URL in Chrome                                                                                                                                               | When              |
-| input element "SELECTOR" has value "VALUE"                                           | Assert that a HTML input element on the web page has the value VALUE                                                                                                    | Then              |
-| element "SELECTOR" should be visible                                                 | Assert that a HTML element on the web page matches SELECTOR                                                                                                             | Then              |
-| the page should have the following content \_CONTENT\_                               | Assert that a HTML element on the web page matches CONTENT selector and value (CONTENT selector must include a HTML id or class - an element type alone will not work!) | Then              |
-| the page should not have the following content \_CONTENT\_                           | Assert that the HTML content specified does NOT exist on the web page                                                                                                   | Then              |
-| the page should contain "KEY" with list element text [LIST] at INT depth             | Assert that the expected breadcrumbs siblings are present                                                                                                               |                   |
-| I fill in input element "SELECTOR" with value "VALUE"                                | Find a HTML input element on the web page that matches SELECTOR and fill it with VALUE                                                                                  | When              |
-| I click the "SELECTOR" element                                                       | Find a HTML element on the web page that matches SELECTOR and simulate a click event                                                                             | When              |
-| the page should be accessible | Assert that the page meets WCAG A and AA accessibility criteria | Then |
-| the page should be accessible with the following exceptions \_LIST\_ | Assert that the page meets WCAG A and AA accessibility criteria whilst ignoring the exceptions. List should be a table of ids taken from the [list of axe-core rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md) | Then |
+## API Feature steps
+
+| Step                                                                                 | What it does                                                                         | Scenario Position |
+|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|-------------------|
+| the following document exists in the "COLLECTION" collection: \_BODY\_               | put document BODY in the COLLECTION collection                                       | Given             |
+| I set the "KEY" header to "VALUE"                                                    | set a HTTP header of the request to the value                                        | Given             |
+| I GET "URL"                                                                          | make a GET request to the provided URL                                               | When              |
+| I DELETE "URL"                                                                       | make a DELETE request to the provided URL                                            | When              |
+| I PUT "URL" "BODY"                                                                   | make a PUT request to the provided URL with the given body                           | When              |
+| I PATCH "URL" "BODY"                                                                 | make a PATCH request to the provided URL with the given body                         | When              |
+| I POST "URL" "BODY"                                                                  | make a POST request to the provided URL with the given body                          | When              |
+| the HTTP status code should be "CODE"                                                | Assert that the response code from the request is CODE                               | Then              |
+| the response header "KEY" should be "VALUE"                                          | Assert that the response header KEY has value VALUE                                  | Then              |
+| I should recieve the following response \_BODY\_                                     | Assert that the response body matches BODY                                           | Then              |
+| I should receive the following JSON response: \_BODY\_                               | Assert that the response body is JSON and that ir matches BODY                       | Then              |
+| I should receive the following JSON response with status "CODE": \_BODY\_            | Assert that the response code is CODE and the body is json which matches BODY        | Then              |
+| I wait "SECONDS" seconds                                                             | Waits a given amount of seconds                                                      | Then              |
+| the document with "KEY" set to "VALUE" does not exist in the "COLLECTION" collection | Assert that a document with KEY set to VALUE does not exist in COLLECTION collection | Then              |
+
 ---
+
+## Authorization Feature steps
+
+| Step                      | What it does                                                   | Scenario Position |
+|---------------------------|----------------------------------------------------------------|-------------------|
+| I am authorised           | set the request Authorization header to a random token         | Given             |
+| I am not authorised       | clear any existing Authorization token from the request        | Given             |
+| I am not identified       | remove the /identity endpoint from the stubbed identity server | Given             |
+| I am identified as "USER" | set /identity endpoint to return response with USER identity   | Given             |
+
+## UI Feature steps
+
+| Step                                                                     | What it does                                                                                        | Scenario Position |
+|--------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|-------------------|
+| I navigate to "URL"                                                      | Navigate to URL in Chrome                                                                           | When              |
+| input element "SELECTOR" has value "VALUE"                               | Assert that a HTML input element on the web page has the value VALUE                                | Then              |
+| element "SELECTOR" should be visible                                     | Assert that a HTML element on the web page matches SELECTOR                                         | Then              |
+| element "SELECTOR" should not be visible                                 | Assert that no HTML element on the web page matches SELECTOR                                        | Then              |
+| the page should have the following content \_CONTENT\_                   | Assert that a HTML element on the web page matches CONTENT selector and value [^1]                  | Then              |
+| the page should contain "KEY" with list element text [LIST] at INT depth | Assert that the expected breadcrumbs siblings are present                                           | Then              |
+| I fill in input element "SELECTOR" with value "VALUE"                    | Find a HTML input element on the web page that matches SELECTOR and fill it with VALUE              | When              |
+| I click the "SELECTOR" element                                           | Find a HTML element on the web page that matches SELECTOR and simulate a click event                | When              |
+| the page should be accessible                                            | Assert that the page meets WCAG A and AA accessibility criteria                                     | Then              |
+| the page should be accessible with the following exceptions \_LIST\_     | Assert that the page meets WCAG A and AA accessibility criteria whilst ignoring the exceptions.[^2] | Then              |
+
+[^1]: CONTENT selector must include a HTML id or class - an element type alone will not work!
+[^2]: List should be a table of ids taken from the [list of axe-core rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md)
 
 ## Example
 


### PR DESCRIPTION
### What

Broke down step definitions into three tables

Removed step which no longer exists (`the page should not have the following content`)
Added step which was not documented (`element "SELECTOR" should not be visible`)

### How to review

Check makes sense and matches feature files. 

### Who can review

Not me. 