### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @ONSdigital/dissemination-open-sauce
-* @ONSdigital/dissemination-data-dissemination
+* @ONSdigital/dissemination-open-sauce @ONSdigital/dissemination-data-dissemination


### PR DESCRIPTION
### What

Fix codeowners syntax to one line. 

### How to review

Check against this: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

### Who can review

Not me. 