### PR TITLE
Add JWT user step

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,1 +1,7 @@
----
+ignore:
+  - id: GO-2026-4883
+    module: github.com/docker/docker
+    reason: No fix available in testcontainers-go; only used for testing, not used by service runtime.
+  - id: GO-2026-4887
+    module: github.com/docker/docker
+    reason: No fix available in testcontainers-go; only used for testing, not used by service runtime.

--- a/STEP_DEFINITIONS.md
+++ b/STEP_DEFINITIONS.md
@@ -67,6 +67,7 @@ variables in the table above.
 | I should receive the following JSON response with status "CODE": \_BODY\_[^1]        | Assert that the response code is CODE and the body is json which matches BODY        | Then              |
 | I wait "SECONDS" seconds                                                             | Waits a given amount of seconds                                                      | Then              |
 | the document with "KEY" set to "VALUE" does not exist in the "COLLECTION" collection | Assert that a document with KEY set to VALUE does not exist in COLLECTION collection | Then              |
+| I am a JWT user with email "EMAIL" and group "COGNITO:GROUP"                         | et the request Authorization header to a JWT token with the provided email and group | Given             |
 
 [^1]: these steps can use the following dynamic values when these are not predictable:
 

--- a/STEP_DEFINITIONS.md
+++ b/STEP_DEFINITIONS.md
@@ -45,29 +45,29 @@ variables in the table above.
 
 ### API Feature steps
 
-| Step                                                                                 | What it does                                                                         | Scenario Position |
-|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|-------------------|
-| the following document exists in the "COLLECTION" collection: \_BODY\_               | put document BODY in the COLLECTION collection                                       | Given             |
-| I set the "KEY" header to "VALUE"                                                    | set a HTTP header of the request to the value                                        | Given             |
-| I am an admin user                                                                   | set the request Authorization header to an admin JWT token                           | Given             |
-| I am a publisher user                                                                | set the request Authorization header to a publisher JWT token                        | Given             |
-| I am not authenticated                                                               | removes any Authorization header set in the request headers                          | Given             |
-| I GET "URL"                                                                          | make a GET request to the provided URL                                               | When              |
-| I DELETE "URL"                                                                       | make a DELETE request to the provided URL                                            | When              |
-| I PUT "URL" "BODY"                                                                   | make a PUT request to the provided URL with the given body                           | When              |
-| I PATCH "URL" "BODY"                                                                 | make a PATCH request to the provided URL with the given body                         | When              |
-| I POST "URL" "BODY"                                                                  | make a POST request to the provided URL with the given body                          | When              |
-| the HTTP status code should be "CODE"                                                | Assert that the response code from the request is CODE                               | Then              |
-| the response header "KEY" should be "VALUE"                                          | Assert that the response header KEY has value VALUE                                  | Then              |
-| I should recieve the following response \_BODY\_                                     | Assert that the response body matches BODY                                           | Then              |
-| I have a healthcheck interval of "SECONDS" seconds                                   | Set the healthcheck interval                                                         | Given             |
-| the health checks should have completed within "SECONDS" seconds                     | Set the expected time for health check completion                                    | When              |
-| I should receive the following health JSON response \_BODY\_                         | Assert that the health check response body matches BODY                              | Then              |
-| I should receive the following JSON response: \_BODY\_[^1]                           | Assert that the response body is JSON and that it matches BODY                       | Then              |
-| I should receive the following JSON response with status "CODE": \_BODY\_[^1]        | Assert that the response code is CODE and the body is json which matches BODY        | Then              |
-| I wait "SECONDS" seconds                                                             | Waits a given amount of seconds                                                      | Then              |
-| the document with "KEY" set to "VALUE" does not exist in the "COLLECTION" collection | Assert that a document with KEY set to VALUE does not exist in COLLECTION collection | Then              |
-| I am a JWT user with email "EMAIL" and group "COGNITO:GROUP"                         | et the request Authorization header to a JWT token with the provided email and group | Given             |
+| Step                                                                                 | What it does                                                                          | Scenario Position |
+|--------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|-------------------|
+| the following document exists in the "COLLECTION" collection: \_BODY\_               | put document BODY in the COLLECTION collection                                        | Given             |
+| I set the "KEY" header to "VALUE"                                                    | set a HTTP header of the request to the value                                         | Given             |
+| I am an admin user                                                                   | set the request Authorization header to an admin JWT token                            | Given             |
+| I am a publisher user                                                                | set the request Authorization header to a publisher JWT token                         | Given             |
+| I am not authenticated                                                               | removes any Authorization header set in the request headers                           | Given             |
+| I GET "URL"                                                                          | make a GET request to the provided URL                                                | When              |
+| I DELETE "URL"                                                                       | make a DELETE request to the provided URL                                             | When              |
+| I PUT "URL" "BODY"                                                                   | make a PUT request to the provided URL with the given body                            | When              |
+| I PATCH "URL" "BODY"                                                                 | make a PATCH request to the provided URL with the given body                          | When              |
+| I POST "URL" "BODY"                                                                  | make a POST request to the provided URL with the given body                           | When              |
+| the HTTP status code should be "CODE"                                                | Assert that the response code from the request is CODE                                | Then              |
+| the response header "KEY" should be "VALUE"                                          | Assert that the response header KEY has value VALUE                                   | Then              |
+| I should recieve the following response \_BODY\_                                     | Assert that the response body matches BODY                                            | Then              |
+| I have a healthcheck interval of "SECONDS" seconds                                   | Set the healthcheck interval                                                          | Given             |
+| the health checks should have completed within "SECONDS" seconds                     | Set the expected time for health check completion                                     | When              |
+| I should receive the following health JSON response \_BODY\_                         | Assert that the health check response body matches BODY                               | Then              |
+| I should receive the following JSON response: \_BODY\_[^1]                           | Assert that the response body is JSON and that it matches BODY                        | Then              |
+| I should receive the following JSON response with status "CODE": \_BODY\_[^1]        | Assert that the response code is CODE and the body is json which matches BODY         | Then              |
+| I wait "SECONDS" seconds                                                             | Waits a given amount of seconds                                                       | Then              |
+| the document with "KEY" set to "VALUE" does not exist in the "COLLECTION" collection | Assert that a document with KEY set to VALUE does not exist in COLLECTION collection  | Then              |
+| I am a JWT user with email "EMAIL" and group "COGNITO:GROUP"                         | Set the request Authorization header to a JWT token with the provided email and group | Given             |
 
 [^1]: these steps can use the following dynamic values when these are not predictable:
 

--- a/api_feature.go
+++ b/api_feature.go
@@ -36,6 +36,7 @@ type APIFeature struct {
 	StartTime            time.Time
 	HealthCheckInterval  time.Duration
 	ExpectedResponseTime time.Duration
+	JWTFeature           *JWTFeature
 }
 
 // HealthCheckTest represents a test healthcheck struct that mimics the real healthcheck struct
@@ -64,6 +65,7 @@ func NewAPIFeature(initialiser ServiceInitialiser) *APIFeature {
 		Initialiser:    initialiser,
 		requestHeaders: make(map[string]string),
 		StartTime:      time.Now(),
+		JWTFeature:     NewJWTFeature(),
 	}
 }
 
@@ -102,6 +104,7 @@ func (f *APIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I use a service auth token "([^"]*)"$`, f.IUseAServiceAuthToken)
 	ctx.Step(`^I use an X Florence user token "([^"]*)"$`, f.IUseAnXFlorenceUserToken)
 	ctx.Step(`^I wait (\d+) seconds`, f.delayTimeBySeconds)
+	ctx.Step(`^I am a JWT user with email "([^"]*)" and group "([^"]*)"$`, f.IUseAJWTToken)
 }
 
 func (f *APIFeature) adminJWTToken() error {
@@ -126,6 +129,16 @@ func (f *APIFeature) IUseAServiceAuthToken(serviceAuthToken string) error {
 
 func (f *APIFeature) IUseAnXFlorenceUserToken(xFlorenceToken string) error {
 	err := f.ISetTheHeaderTo("X-Florence-Token", xFlorenceToken)
+	return err
+}
+
+func (f *APIFeature) IUseAJWTToken(email, groups string) error {
+	groupsArray := strings.Split(groups, ",")
+	token, err := f.JWTFeature.CreateJWT(email, groupsArray)
+	if err != nil {
+		return err
+	}
+	err = f.ISetTheHeaderTo("Authorization", "Bearer "+token)
 	return err
 }
 

--- a/examples/jwt_authorization/features/example.feature
+++ b/examples/jwt_authorization/features/example.feature
@@ -1,0 +1,6 @@
+Feature: Example feature
+
+  Scenario: Accessing endpoint with JWT authorization
+    Given I am a JWT user with email "viewer1@ons.gov.uk" and group "role-viewer-allowed"
+    When I GET "/checkjwt"
+    Then The HTTP status code should be "200"

--- a/examples/jwt_authorization/main.go
+++ b/examples/jwt_authorization/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/gorilla/mux"
+)
+
+type Config struct {
+	AuthConfig AuthConfig
+}
+
+type AuthConfig struct {
+	JWTVerificationPublicKeys map[string]string
+}
+
+func NewConfig() *Config {
+	return &Config{
+		AuthConfig: AuthConfig{JWTVerificationPublicKeys: map[string]string{}},
+	}
+}
+
+func ExampleHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(201)
+	fmt.Fprintf(w, "accepted")
+}
+
+func NewRouter(cfg *Config) http.Handler {
+	router := mux.NewRouter().StrictSlash(true)
+
+	router.HandleFunc("/checkjwt", checkJWT(cfg)).Methods(http.MethodGet)
+
+	return router
+}
+
+func checkJWT(config *Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tokenString := r.Header.Get("Authorization")
+		if tokenString == "" {
+			http.Error(w, "missing Authorization header", http.StatusUnauthorized)
+			return
+		}
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		tokenString = strings.TrimSpace(tokenString)
+
+		keyFunc := func(token *jwt.Token) (interface{}, error) {
+			kid, _ := token.Header["kid"].(string)
+			pubKeyB64 := config.AuthConfig.JWTVerificationPublicKeys[kid]
+			pubKeyDER, _ := base64.StdEncoding.DecodeString(pubKeyB64)
+			pubKey, _ := x509.ParsePKIXPublicKey(pubKeyDER)
+			return pubKey, nil
+		}
+
+		token, err := jwt.Parse(tokenString, keyFunc)
+		if err != nil || !token.Valid {
+			http.Error(w, "invalid token: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func main() {
+	cfg := NewConfig()
+	server := &http.Server{
+		Addr:              ":10000",
+		Handler:           NewRouter(cfg),
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	log.Fatal(server.ListenAndServe())
+}

--- a/examples/jwt_authorization/main_test.go
+++ b/examples/jwt_authorization/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	componenttest "github.com/ONSdigital/dp-component-test"
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/colors"
+)
+
+var componentFlag = flag.Bool("component", false, "perform component tests")
+
+func InitializeScenario(godogCtx *godog.ScenarioContext) {
+	authorizationFeature := componenttest.NewAuthorizationFeature()
+	cfg := NewConfig()
+	myAppFeature := NewMyAppComponent(cfg)
+	apiFeature := componenttest.NewAPIFeatureWithHandler(myAppFeature.Handler)
+
+	key, _ := apiFeature.JWTFeature.EnsureKeys()
+	cfg.AuthConfig.JWTVerificationPublicKeys[key.KID] = key.PublicKeyB64
+
+	godogCtx.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		apiFeature.Reset()
+		authorizationFeature.Reset()
+		return ctx, nil
+	})
+
+	godogCtx.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		authorizationFeature.Close()
+		return ctx, nil
+	})
+
+	apiFeature.RegisterSteps(godogCtx)
+	authorizationFeature.RegisterSteps(godogCtx)
+}
+
+func TestComponent(t *testing.T) {
+	if *componentFlag {
+		var opts = godog.Options{
+			Output: colors.Colored(os.Stdout),
+			Paths:  flag.Args(),
+			Format: "pretty",
+		}
+
+		status := godog.TestSuite{
+			Name:                "component_tests",
+			ScenarioInitializer: InitializeScenario,
+			Options:             &opts,
+		}.Run()
+
+		if status > 0 {
+			t.Fail()
+		}
+	} else {
+		t.Skip()
+	}
+}

--- a/examples/jwt_authorization/myapp_component.go
+++ b/examples/jwt_authorization/myapp_component.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"net/http"
+)
+
+type MyAppComponent struct {
+	Handler http.Handler
+	Config  *Config
+}
+
+func NewMyAppComponent(cfg *Config) *MyAppComponent {
+	return &MyAppComponent{
+		Config:  cfg,
+		Handler: NewRouter(cfg),
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/chromedp/cdproto v0.0.0-20250630014756-b7288190f53c
 	github.com/chromedp/chromedp v0.13.7
 	github.com/cucumber/godog v0.15.0
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/jwt_feature.go
+++ b/jwt_feature.go
@@ -1,0 +1,78 @@
+package componenttest
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+)
+
+type Key struct {
+	KID          string
+	PublicKeyB64 string
+}
+
+type JWTFeature struct {
+	privKey      *rsa.PrivateKey
+	kid          string
+	publicKeyB64 string
+}
+
+func NewJWTFeature() *JWTFeature {
+	return &JWTFeature{}
+}
+
+// EnsureKeys needs to be called in the test setup or reset step of the component tests in the service
+// you're testing so that the keys can be set in the AuthConfig.JWTVerificationPublicKeys map and the JWTs can
+// be verified by the service under test
+func (j *JWTFeature) EnsureKeys() (Key, error) {
+	if j.privKey == nil || j.kid == "" || j.publicKeyB64 == "" {
+		priv, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return Key{}, fmt.Errorf("generate viewer RSA key: %w", err)
+		}
+		if err := priv.Validate(); err != nil {
+			return Key{}, fmt.Errorf("validate viewer RSA key: %w", err)
+		}
+
+		newKID := uuid.New().String()
+		pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+		if err != nil {
+			return Key{}, fmt.Errorf("marshal viewer public key: %w", err)
+		}
+
+		j.privKey = priv
+		j.kid = newKID
+		j.publicKeyB64 = base64.StdEncoding.EncodeToString(pubDER)
+	}
+	return Key{
+		KID:          j.kid,
+		PublicKeyB64: j.publicKeyB64,
+	}, nil
+}
+
+func (j *JWTFeature) CreateJWT(email string, groups []string) (string, error) {
+	now := time.Now().Unix()
+	claims := jwt.MapClaims{
+		"sub":            "viewer-sub",
+		"token_use":      "access",
+		"auth_time":      now,
+		"iss":            "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_example",
+		"exp":            now + 3600,
+		"iat":            now,
+		"client_id":      "component-test-client",
+		"username":       email,
+		"cognito:groups": groups,
+	}
+
+	t := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	t.Header["kid"] = j.kid
+
+	signed, err := t.SignedString(j.privKey)
+	return signed, err
+}


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4646?atlOrigin=eyJpIjoiNzUwMzc5OWNiNGEzNDM5Mjg1ZWNjMjgxZWQ3OGRmYjEiLCJwIjoiaiJ9

We had steps duplicated in the component tests in different services so we wanted to consolidate them here.
This PR adds a new step that can be used to generate a JWT token to authenticate a user in component tests.

### How to review

`make test-component` and check they pass

Follow the steps in the following two PRs to check the steps work in practice:
https://github.com/ONSdigital/dp-dataset-api/pull/698
https://github.com/ONSdigital/dp-files-api/pull/197

### Who can review

Anyone