### PR TITLE
update mongo connection string

### DIFF
--- a/mongo_feature.go
+++ b/mongo_feature.go
@@ -18,9 +18,10 @@ import (
 
 // MongoFeature is a struct containing a mongo database in a container
 type MongoFeature struct {
-	Server   *testMongo.MongoDBContainer
-	Client   mongo.Client
-	Database *mongo.Database
+	Server           *testMongo.MongoDBContainer
+	Client           mongo.Client
+	Database         *mongo.Database
+	connectionString string
 }
 
 // MongoOptions contains a set of options required to create a new MongoFeature
@@ -101,17 +102,20 @@ func NewMongoFeature(mongoOptions MongoOptions) *MongoFeature {
 	database := client.Database(mongoOptions.DatabaseName)
 
 	return &MongoFeature{
-		Server:   mongoContainer,
-		Client:   *client,
-		Database: database,
+		Server:           mongoContainer,
+		Client:           *client,
+		Database:         database,
+		connectionString: endpoint,
 	}
 }
 
 // GetConnectionString returns the MongoDB connection string for the container
 func (m *MongoFeature) GetConnectionString() (string, error) {
+	if m.connectionString != "" {
+		return m.connectionString, nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-
 	return m.Server.ConnectionString(ctx)
 }
 


### PR DESCRIPTION
### What

Potential fix for flaky component tests in dis-bundle-api. Updated the connection string returned to services to include `directConnection=true` when using a replica set, to hopefully prevent intermittent NotWritablePrimary errors in component tests

It's an addition to the changes made in this PR - https://github.com/ONSdigital/dp-component-test/pull/78

### How to review

Confirm changes are ok
We will be able to see if the fix has had any effect once a few PR's have gone into the bundle api

### Who can review

Anyone
