### PR TITLE
add mongo write check

### DIFF
--- a/mongo_feature.go
+++ b/mongo_feature.go
@@ -13,7 +13,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
 // MongoFeature is a struct containing a mongo database in a container
@@ -89,11 +88,16 @@ func NewMongoFeature(mongoOptions MongoOptions) *MongoFeature {
 		waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer waitCancel()
 		for {
-			if err := client.Ping(waitCtx, readpref.Primary()); err == nil {
-				break
+			err := client.Database(mongoOptions.DatabaseName).RunCommand(waitCtx, bson.D{{Key: "ping", Value: 1}}).Err()
+			if err == nil {
+				_, writeErr := client.Database(mongoOptions.DatabaseName).Collection("_health_check").InsertOne(waitCtx, bson.D{{Key: "ping", Value: 1}})
+				if writeErr == nil {
+					_ = client.Database(mongoOptions.DatabaseName).Collection("_health_check").Drop(waitCtx)
+					break
+				}
 			}
 			if waitCtx.Err() != nil {
-				panic("timed out waiting for MongoDB primary election")
+				panic("timed out waiting for MongoDB primary to be ready for writes")
 			}
 			time.Sleep(500 * time.Millisecond)
 		}


### PR DESCRIPTION
### What

Component tests are still intermittently failing in the bundle api. This is just an update to the wait loop added in this PR - https://github.com/ONSdigital/dp-component-test/pull/78
Updated the mongo replica set wait loop to do a test write instead of just a ping, to make sure that the primary is actually ready to accept writes before the tests start running

### How to review

Confirm changes make sense

### Who can review

Anyone
